### PR TITLE
finish-args remove pipewire and LC_NUMERIC

### DIFF
--- a/org.kde.haruna.yml
+++ b/org.kde.haruna.yml
@@ -14,10 +14,8 @@ finish-args:
   - --device=dri
   - --filesystem=host:ro
   - --filesystem=home
-  - --filesystem=xdg-run/pipewire-0:ro
   - --talk-name=org.freedesktop.ScreenSaver
   - --own-name=org.mpris.MediaPlayer2.haruna
-  - --env=LC_NUMERIC=C
 cleanup:
   - '*.a'
   - '*.la'


### PR DESCRIPTION
`--filesystem=xdg-run/pipewire-0:ro`, causes haruna to freeze on linux mint
`--env=LC_NUMERIC=C`, not needed